### PR TITLE
Add ability to delete custom aliases

### DIFF
--- a/net.isometry.alfred.pipe/README.md
+++ b/net.isometry.alfred.pipe/README.md
@@ -23,6 +23,8 @@ A number of built-in pipelines are [included](https://raw.github.com/isometry/al
 
 `| alias tac=sed '1!G;h;$!d'@@`
 
+You can delete custom aliases by actioning on them while holding the `alt` key.
+
 ## Contributions & Thanks
 
 - ctwise

--- a/net.isometry.alfred.pipe/info.plist
+++ b/net.isometry.alfred.pipe/info.plist
@@ -15,6 +15,8 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
 			</dict>
 		</array>
 		<key>74681B4B-CBE4-403F-BDF7-39F4D2319ABD</key>
@@ -26,6 +28,18 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>EF5EB2B1-078B-466F-B3B0-2CE638E650C2</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string>remove alias</string>
+				<key>vitoclose</key>
+				<false/>
 			</dict>
 		</array>
 		<key>880D9394-A59A-4BC1-BB46-01461CEFEE80</key>
@@ -37,6 +51,31 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>EF5EB2B1-078B-466F-B3B0-2CE638E650C2</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string>remove alias</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>B97A60DC-8C38-4072-8518-EDF6BFD232A1</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>BBE24661-24FE-4955-8734-7D3AA33282F4</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
 			</dict>
 		</array>
 		<key>CCEE8787-6024-46B4-B155-240F86561281</key>
@@ -48,6 +87,8 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
 			</dict>
 		</array>
 		<key>D029EE08-8642-404B-83FE-BB5DFEE9C6B6</key>
@@ -59,6 +100,8 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
 			</dict>
 		</array>
 		<key>D637E280-521E-432F-85C1-3F58E064A66E</key>
@@ -70,6 +113,21 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>EF5EB2B1-078B-466F-B3B0-2CE638E650C2</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>B97A60DC-8C38-4072-8518-EDF6BFD232A1</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
 			</dict>
 		</array>
 	</dict>
@@ -83,6 +141,29 @@
 	<string>pipe</string>
 	<key>objects</key>
 	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>0</integer>
+				<key>script</key>
+				<string>pbpaste | {query} | pbcopy</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>5</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>16039760-F173-4AB8-9C73-DA7401D5DE23</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
@@ -100,24 +181,46 @@
 				<false/>
 				<key>modsmode</key>
 				<integer>0</integer>
+				<key>relatedAppsMode</key>
+				<integer>0</integer>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.trigger.hotkey</string>
 			<key>uid</key>
 			<string>D637E280-521E-432F-85C1-3F58E064A66E</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
 				<key>argumenttype</key>
 				<integer>0</integer>
 				<key>escaping</key>
 				<integer>0</integer>
 				<key>keyword</key>
 				<string>|</string>
+				<key>queuedelaycustom</key>
+				<integer>1</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<false/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
 				<key>script</key>
 				<string>from pipe import complete
 print complete("""{query}""")</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
 				<key>title</key>
 				<string>Pipe clipboard through one-liner</string>
 				<key>type</key>
@@ -129,34 +232,110 @@ print complete("""{query}""")</string>
 			<string>alfred.workflow.input.scriptfilter</string>
 			<key>uid</key>
 			<string>74681B4B-CBE4-403F-BDF7-39F4D2319ABD</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>autopaste</key>
+				<key>lastpathcomponent</key>
+				<false/>
+				<key>onlyshowifquerypopulated</key>
 				<true/>
-				<key>clipboardtext</key>
-				<string>{query}</string>
+				<key>removeextension</key>
+				<false/>
+				<key>text</key>
+				<string>alias {query} deleted</string>
+				<key>title</key>
+				<string>Alias deleted</string>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.output.clipboard</string>
+			<string>alfred.workflow.output.notification</string>
 			<key>uid</key>
-			<string>0FCF109F-A181-4D53-A4DB-DB54DA7440B8</string>
+			<string>BBE24661-24FE-4955-8734-7D3AA33282F4</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>0</integer>
+				<key>keyword</key>
+				<string>pipe</string>
+				<key>queuedelaycustom</key>
+				<integer>1</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<false/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>from pipe import complete
+print complete("""{query}""")</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Pipe clipboard through one-liner</string>
+				<key>type</key>
+				<integer>3</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>880D9394-A59A-4BC1-BB46-01461CEFEE80</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
 				<key>escaping</key>
 				<integer>0</integer>
 				<key>script</key>
-				<string>pbpaste | {query}</string>
+				<string>from pipe import remove
+print remove("""{query}""")</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
 				<key>type</key>
-				<integer>5</integer>
+				<integer>3</integer>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.action.script</string>
 			<key>uid</key>
-			<string>D029EE08-8642-404B-83FE-BB5DFEE9C6B6</string>
+			<string>EF5EB2B1-078B-466F-B3B0-2CE638E650C2</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.transform</string>
+			<key>uid</key>
+			<string>B97A60DC-8C38-4072-8518-EDF6BFD232A1</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -175,11 +354,15 @@ print complete("""{query}""")</string>
 				<false/>
 				<key>modsmode</key>
 				<integer>0</integer>
+				<key>relatedAppsMode</key>
+				<integer>0</integer>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.trigger.hotkey</string>
 			<key>uid</key>
 			<string>CCEE8787-6024-46B4-B155-240F86561281</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -195,19 +378,62 @@ end alfred_script</string>
 			<string>alfred.workflow.action.applescript</string>
 			<key>uid</key>
 			<string>E8AC122D-DD51-491F-A734-C89446EB1924</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>0</integer>
+				<key>script</key>
+				<string>pbpaste | {query}</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>5</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>D029EE08-8642-404B-83FE-BB5DFEE9C6B6</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
 				<key>argumenttype</key>
 				<integer>0</integer>
 				<key>escaping</key>
 				<integer>0</integer>
 				<key>keyword</key>
 				<string>||</string>
+				<key>queuedelaycustom</key>
+				<integer>1</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<false/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
 				<key>script</key>
 				<string>from pipe import complete
 print complete("""{query}""")</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
 				<key>title</key>
 				<string>Pipe clipboard through one-liner and paste</string>
 				<key>type</key>
@@ -219,45 +445,25 @@ print complete("""{query}""")</string>
 			<string>alfred.workflow.input.scriptfilter</string>
 			<key>uid</key>
 			<string>64D17591-D71C-421B-B701-91E99A3C0318</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>argumenttype</key>
-				<integer>0</integer>
-				<key>escaping</key>
-				<integer>0</integer>
-				<key>keyword</key>
-				<string>pipe</string>
-				<key>script</key>
-				<string>from pipe import complete
-print complete("""{query}""")</string>
-				<key>title</key>
-				<string>Pipe clipboard through one-liner</string>
-				<key>type</key>
-				<integer>3</integer>
-				<key>withspace</key>
+				<key>autopaste</key>
 				<true/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>transient</key>
+				<false/>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.input.scriptfilter</string>
+			<string>alfred.workflow.output.clipboard</string>
 			<key>uid</key>
-			<string>880D9394-A59A-4BC1-BB46-01461CEFEE80</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>escaping</key>
-				<integer>0</integer>
-				<key>script</key>
-				<string>pbpaste | {query} | pbcopy</string>
-				<key>type</key>
-				<integer>5</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>16039760-F173-4AB8-9C73-DA7401D5DE23</string>
+			<string>0FCF109F-A181-4D53-A4DB-DB54DA7440B8</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 	</array>
 	<key>readme</key>
@@ -271,48 +477,87 @@ print complete("""{query}""")</string>
 	<dict>
 		<key>0FCF109F-A181-4D53-A4DB-DB54DA7440B8</key>
 		<dict>
+			<key>xpos</key>
+			<integer>700</integer>
 			<key>ypos</key>
 			<real>420</real>
 		</dict>
 		<key>16039760-F173-4AB8-9C73-DA7401D5DE23</key>
 		<dict>
+			<key>xpos</key>
+			<integer>500</integer>
 			<key>ypos</key>
 			<real>60</real>
 		</dict>
 		<key>64D17591-D71C-421B-B701-91E99A3C0318</key>
 		<dict>
+			<key>xpos</key>
+			<integer>300</integer>
 			<key>ypos</key>
 			<real>420</real>
 		</dict>
 		<key>74681B4B-CBE4-403F-BDF7-39F4D2319ABD</key>
 		<dict>
+			<key>xpos</key>
+			<integer>300</integer>
 			<key>ypos</key>
 			<real>60</real>
 		</dict>
 		<key>880D9394-A59A-4BC1-BB46-01461CEFEE80</key>
 		<dict>
+			<key>xpos</key>
+			<integer>300</integer>
 			<key>ypos</key>
 			<real>180</real>
 		</dict>
+		<key>B97A60DC-8C38-4072-8518-EDF6BFD232A1</key>
+		<dict>
+			<key>xpos</key>
+			<integer>670</integer>
+			<key>ypos</key>
+			<integer>210</integer>
+		</dict>
+		<key>BBE24661-24FE-4955-8734-7D3AA33282F4</key>
+		<dict>
+			<key>xpos</key>
+			<integer>760</integer>
+			<key>ypos</key>
+			<integer>180</integer>
+		</dict>
 		<key>CCEE8787-6024-46B4-B155-240F86561281</key>
 		<dict>
+			<key>xpos</key>
+			<integer>100</integer>
 			<key>ypos</key>
 			<real>300</real>
 		</dict>
 		<key>D029EE08-8642-404B-83FE-BB5DFEE9C6B6</key>
 		<dict>
+			<key>xpos</key>
+			<integer>500</integer>
 			<key>ypos</key>
 			<real>420</real>
 		</dict>
 		<key>D637E280-521E-432F-85C1-3F58E064A66E</key>
 		<dict>
+			<key>xpos</key>
+			<integer>100</integer>
 			<key>ypos</key>
 			<real>60</real>
 		</dict>
 		<key>E8AC122D-DD51-491F-A734-C89446EB1924</key>
 		<dict>
+			<key>xpos</key>
+			<integer>500</integer>
 			<key>ypos</key>
 			<real>300</real>
+		</dict>
+		<key>EF5EB2B1-078B-466F-B3B0-2CE638E650C2</key>
+		<dict>
+			<key>xpos</key>
+			<integer>500</integer>
+			<key>ypos</key>
+			<integer>180</integer>
 		</dict>
 	</dict>
 	<key>webaddress</key>

--- a/net.isometry.alfred.pipe/pipe.py
+++ b/net.isometry.alfred.pipe/pipe.py
@@ -119,3 +119,16 @@ def complete(query, maxresults=_MAX_RESULTS):
         results.extend(matches)
 
     return alfred.xml(results, maxresults=maxresults)
+
+def remove(query):
+    aliases = fetch_aliases()
+    keyname = ''
+    for key, value in aliases.items():
+        if value == query:
+            aliases.pop(key, None)
+            keyname = key
+
+    file = path.join(alfred.work(volatile=False), _ALIASES_FILE)
+    json.dump(aliases, open(file, 'w'), indent=4, separators=(',', ': '))
+
+    return keyname


### PR DESCRIPTION
This a feature request and a rather naive approach to deleting custom aliases; yet it works. Plus, it's the first time I've ever touched anything Python :)

To avoid changing anything I added the new `remove` function (or def) to handle the actual alias script as payload, and search for it in the aliases dictionary with a simple for loop. Once found, it removes it from the dict and re-writes it.
Since I couldn't strip the newline from the final print I used the new Alfred 3 filter to remove it and show the notification or not accordingly.

Hope it's a nice addition. I basically did it out of my own need.
Cheers!
